### PR TITLE
Add GitHub-authenticated setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,13 +80,13 @@ Contains the Infrastructure as Code (IaC) configurations for deploying and manag
 
 ### Local Development
 
-1.  **Clone Repositories:** It is recommended to clone all relevant Pulse component repositories. While a setup script (`setup_repos.sh`) may be available, manual cloning is also an option:
+1.  **Clone Repositories:** Use the `setup.sh` script to clone all Pulse repositories. Provide your GitHub credentials via environment variables:
     ```bash
-    # Example for the core pulse repository:
-    git clone <URL_to_pulse_repository> 
-    # Repeat for other component repositories (pulse-ui, pulse-apis, etc.)
+    export GITHUB_USERNAME=<your-username>
+    export GITHUB_TOKEN=<your-token>
+    ./setup.sh
     ```
-    *Note: Refer to the central project documentation or internal resources for the precise repository URLs.*
+    If authentication isn't required, you can run `setup_repos.sh` directly or clone repositories manually.
 
 2.  **Install Dependencies:** Navigate into each cloned repository directory and install its specific dependencies.
     ```bash

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# setup.sh - Configure GitHub authentication and clone all Pulse repositories.
+# Usage: ./setup.sh [target-directory]
+# Environment variables required:
+#   GITHUB_USERNAME - GitHub username
+#   GITHUB_TOKEN    - GitHub personal access token
+
+set -euo pipefail
+
+if [[ -z "${GITHUB_USERNAME:-}" || -z "${GITHUB_TOKEN:-}" ]]; then
+  echo "[ERROR] GITHUB_USERNAME and GITHUB_TOKEN must be set in the environment" >&2
+  exit 1
+fi
+
+# Preserve existing credential helper if any
+ORIGINAL_HELPER=$(git config --global --get credential.helper || true)
+TEMP_CREDS="$(mktemp)"
+
+cleanup() {
+  if [[ -n "${ORIGINAL_HELPER}" ]]; then
+    git config --global credential.helper "${ORIGINAL_HELPER}"
+  else
+    git config --global --unset credential.helper >/dev/null 2>&1 || true
+  fi
+  rm -f "${TEMP_CREDS}"
+}
+trap cleanup EXIT
+
+# Store temporary credentials for GitHub
+printf "https://%s:%s@github.com\n" "$GITHUB_USERNAME" "$GITHUB_TOKEN" > "${TEMP_CREDS}"
+git config --global credential.helper "store --file=${TEMP_CREDS}"
+
+# Run repository setup with the provided target directory
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+"${SCRIPT_DIR}/setup_repos.sh" "${1:-.}"
+


### PR DESCRIPTION
## Summary
- introduce `setup.sh` to allow cloning Pulse repos with GitHub credentials
- document the new script and usage in README

## Testing
- `bash -n setup.sh`
- `shellcheck setup.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a553fb9588328b738f3dda6a9e8e0